### PR TITLE
Preliminary feature flagging work for crypt_safe_free build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,7 @@ addons:
     packages:
       - libcryptsetup-dev
       - keyutils
-<<<<<<< HEAD
       - libkeyutils-dev
-=======
-      - keyutils-libs-devel
->>>>>>> Fix .travis.yml
 
 language: rust
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,11 @@ addons:
     packages:
       - libcryptsetup-dev
       - keyutils
+<<<<<<< HEAD
       - libkeyutils-dev
+=======
+      - keyutils-libs-devel
+>>>>>>> Fix .travis.yml
 
 language: rust
 matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ libc = "0.2.60"
 serde_json = "1.0"
 uuid = "0.7.4"
 
+[build-dependencies]
+pkg-config = "0.3"
+
 [dev-dependencies]
 base64 = "0.10"
 loopdev = "0.2"

--- a/libcryptsetup-rs-sys/Cargo.toml
+++ b/libcryptsetup-rs-sys/Cargo.toml
@@ -11,4 +11,5 @@ repository = "https://github.com/stratis-storage/libcryptsetup-rs"
 
 [build-dependencies]
 bindgen = "0.53.0"
+pkg-config = "0.3"
 cc = "1.0.45"

--- a/libcryptsetup-rs-sys/build.rs
+++ b/libcryptsetup-rs-sys/build.rs
@@ -2,23 +2,46 @@ use std::env;
 
 use bindgen;
 use cc;
+use pkg_config::Config;
 
 use std::path::PathBuf;
 
-fn main() {
+fn safe_free_is_needed() -> bool {
+    match Config::new().atleast_version("2.3.0").probe("libcryptsetup") {
+        Ok(_) => false,
+        Err(_) => {
+            match Config::new().atleast_version("2.2.0").probe("libcryptsetup") {
+                Ok(_) => true,
+                Err(e) => panic!("Bindings require at least cryptsetup-2.2: {}", e),
+            }
+        }
+    }
+}
+
+fn build_safe_free() {
     println!("cargo:rustc-link-lib=cryptsetup");
 
     cc::Build::new().file("safe_free.c").compile("safe_free");
+}
 
-    let bindings = bindgen::Builder::default()
-        .header("header.h")
-        .header("safe_free.h")
-        .size_t_is_usize(true)
-        .generate()
+fn generate_bindings(safe_free_is_needed: bool) {
+    let mut builder = bindgen::Builder::default().header("header.h").size_t_is_usize(true);
+    if safe_free_is_needed {
+        builder = builder.header("safe_free.h");
+    }
+    let bindings = builder.generate()
         .expect("Unable to generate bindings");
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings");
+}
+
+fn main() {
+    let safe_free_is_needed = safe_free_is_needed();
+    if safe_free_is_needed {
+        build_safe_free();
+    }
+    generate_bindings(safe_free_is_needed);
 }

--- a/libcryptsetup-rs-sys/build.rs
+++ b/libcryptsetup-rs-sys/build.rs
@@ -25,11 +25,14 @@ fn build_safe_free() {
 }
 
 fn generate_bindings(safe_free_is_needed: bool) {
-    let mut builder = bindgen::Builder::default().header("header.h").size_t_is_usize(true);
-    if safe_free_is_needed {
-        builder = builder.header("safe_free.h");
-    }
-    let bindings = builder.generate()
+    let builder = bindgen::Builder::default().header("header.h").size_t_is_usize(true);
+    let builder_with_safe_free = if safe_free_is_needed {
+        builder.header("safe_free.h")
+    } else {
+        builder
+    };
+    let bindings = builder_with_safe_free
+        .generate()
         .expect("Unable to generate bindings");
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ mod key;
 pub use key::CryptVolumeKey;
 
 mod keyfile;
-pub use keyfile::{CryptKeyfile, CryptKeyfileContents};
+pub use keyfile::{CryptKeyfile, CryptKeyfileContents, CryptKeyfileFlag, CryptKeyfileFlags};
 
 mod keyslot;
 pub use keyslot::{
@@ -152,5 +152,11 @@ mod test {
     #[test]
     fn test_unencrypted() {
         tests::encrypt::test_unecrypted();
+    }
+
+    #[ignore]
+    #[test]
+    fn test_crypt_setup_free_exists() {
+        tests::keyfile::test_keyfile_cleanup();
     }
 }

--- a/src/tests/keyfile.rs
+++ b/src/tests/keyfile.rs
@@ -11,7 +11,8 @@ pub fn test_keyfile_cleanup() {
         super::do_cleanup(),
         |dev_path, _file_path| {
             let mut device = CryptInit::init(dev_path)?;
-            let mut key_path = PathBuf::from(env::var("TEST_DIR").unwrap_or("/tmp".to_string()));
+            let mut key_path =
+                PathBuf::from(env::var("TEST_DIR").unwrap_or_else(|_| "/tmp".to_string()));
             key_path.push("safe-free-test-keyfile");
             let mut f = File::create(&key_path).map_err(LibcryptErr::IOError)?;
             f.write(b"this is a test password")

--- a/src/tests/keyfile.rs
+++ b/src/tests/keyfile.rs
@@ -1,0 +1,42 @@
+use std::{fs::File, io::Write, path::PathBuf};
+
+use super::loopback;
+
+use crate::{CryptInit, CryptKeyfileFlags, LibcryptErr};
+
+pub fn test_keyfile_cleanup() {
+    loopback::use_loopback(
+        50 * 1024 * 1024,
+        super::format_with_zeros(),
+        super::do_cleanup(),
+        |dev_path, _file_path| {
+            let mut device = CryptInit::init(dev_path)?;
+            let key_path = &PathBuf::from("/tmp/safe-free-test-keyfile");
+            let mut f = File::create(key_path).map_err(LibcryptErr::IOError)?;
+            f.write(b"this is a test password")
+                .map_err(LibcryptErr::IOError)?;
+            let keyfile_contents =
+                device
+                    .keyfile_handle()
+                    .device_read(key_path, 0, None, CryptKeyfileFlags::empty());
+            std::fs::remove_file(key_path).map_err(LibcryptErr::IOError)?;
+            let (keyfile_ptr, keyfile_len) = {
+                let keyfile_contents = keyfile_contents?;
+
+                let keyfile_ref = keyfile_contents.as_ref();
+                assert_eq!(keyfile_ref, b"this is a test password" as &[u8]);
+
+                (keyfile_ref.as_ptr(), keyfile_ref.len())
+            };
+
+            let dangling_buffer =
+                unsafe { std::slice::from_raw_parts(keyfile_ptr as *const u8, keyfile_len) };
+            if dangling_buffer == b"this is a test password" {
+                panic!("Key was not cleaned up!");
+            }
+
+            Ok(())
+        },
+    )
+    .expect("Should succeed");
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,6 +5,7 @@
 use std::env::var;
 
 pub mod encrypt;
+pub mod keyfile;
 pub mod loopback;
 
 fn format_with_zeros() -> bool {


### PR DESCRIPTION
This PR should make libcryptsetup-rs compatible on both 2.2 and 2.3 and higher by feature flagging the C implementation of `crypt_safe_free` in libcryptsetup based on the system libcryptsetup version.

Related to #2 and #5 