### PR TITLE
Update readme with links to relevant sites including self-hosted documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/jbaublitz/neli.svg?branch=master)](https://travis-ci.org/jbaublitz/neli)
+[![Build Status](https://travis-ci.org/stratis-storage/libcryptsetup-rs.svg?branch=master)](https://travis-ci.org/stratis-storage/libcryptsetup-rs)
 [![Latest Version](https://img.shields.io/crates/v/libcryptsetup-rs.svg)](https://crates.io/crates/libcryptsetup-rs)
 [![Documentation](https://docs.rs/libcryptsetup-rs/badge.svg)](https://stratis-storage.github.io/libcryptsetup-rs/doc/libcryptsetup_rs/index.html)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
+[![Build Status](https://travis-ci.org/jbaublitz/neli.svg?branch=master)](https://travis-ci.org/jbaublitz/neli)
+[![Latest Version](https://img.shields.io/crates/v/libcryptsetup-rs.svg)](https://crates.io/crates/libcryptsetup-rs)
+[![Documentation](https://docs.rs/libcryptsetup-rs/badge.svg)](https://stratis-storage.github.io/libcryptsetup-rs/doc/libcryptsetup_rs/index.html)
+
 # libcryptsetup-rs
 
 This crate provides Rust bindings for libcryptsetup.
+
+### API documentation
+
+The API documentation can be found [here](https://stratis-storage.github.io/libcryptsetup-rs/doc/libcryptsetup_rs/index.html)
 
 ### Sanity testing bindings
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This crate provides Rust bindings for libcryptsetup.
 
 ### API documentation
 
-The API documentation can be found [here](https://stratis-storage.github.io/libcryptsetup-rs/doc/libcryptsetup_rs/index.html)
+The API documentation can be found [here](https://stratis-storage.github.io/libcryptsetup-rs/doc/libcryptsetup_rs/index.html).
 
 ### Sanity testing bindings
 


### PR DESCRIPTION
You can view the rendered results of the README pull request [here](https://github.com/jbaublitz/libcryptsetup-rs/tree/update-readme) vs. the old one [here](https://github.com/stratis-storage/libcryptsetup-rs/).