### PR TITLE
Version 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcryptsetup-rs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["John Baublitz <jbaublitz@redhat.com>"]
 edition = "2018"
 description = "High level Rust bindings for libcryptsetup"
@@ -10,14 +10,17 @@ homepage = "https://stratis-storage.github.io/"
 repository = "https://github.com/stratis-storage/libcryptsetup-rs-sys"
 
 [dependencies.libcryptsetup-rs-sys]
-version = "0.1.0"
+version = "0.1.1"
 path = "./libcryptsetup-rs-sys"
 
 [dependencies]
 either = "1.5"
 libc = "0.2.60"
 serde_json = "1.0"
-uuid = {version = "0.7.4", features = ["v4"]}
+
+[dependencies.uuid]
+version = "0.7.4"
+features = ["v4"]
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/libcryptsetup-rs-sys/Cargo.toml
+++ b/libcryptsetup-rs-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcryptsetup-rs-sys"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["John Baublitz <jbaublitz@redhat.com>"]
 edition = "2018"
 description = "Low level bindings for libcryptsetup"


### PR DESCRIPTION
I've bumped libcryptsetup-rs-sys to v0.1.1 because of #23 which does not change the API or semantics but is an important change to the code that needs to be propagated moving forward with cryptsetup 2.3.

libcryptsetup-rs will be v0.2.0 because we have made some breaking API changes.