### PR TITLE
Fix Makefile phony target list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,4 @@ test-loopback:
 	fmt-travis
 	release
 	test
+	test-loopback


### PR DESCRIPTION
There was one target missing from the `.PHONY` list.