### PR TITLE
Optional device argument to crypt_status()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub use settings::{
 };
 
 mod status;
-pub use status::{CryptDeviceStatus, CryptStatusInfo};
+pub use status::{status, CryptDeviceStatus, CryptStatusInfo};
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
`crypt_status()` can actually take a `NULL` pointer for device context. This would be useful to expose to stratisd when checking if a device is active or not.