### PR TITLE
Handle null ptr in json_set, status

### DIFF
--- a/examples/format-luks2-with-token.rs
+++ b/examples/format-luks2-with-token.rs
@@ -4,7 +4,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use libcryptsetup_rs::{c_uint, CryptInit, CryptVolumeKeyFlags, EncryptionFormat, LibcryptErr};
+use libcryptsetup_rs::{
+    c_uint, CryptInit, CryptVolumeKeyFlags, EncryptionFormat, LibcryptErr, TokenInput,
+};
 
 #[macro_use]
 extern crate serde_json;
@@ -101,15 +103,12 @@ fn proto_token_handler(dev: &Path, key_description: &str) -> Result<(), Libcrypt
         .context_handle()
         .load::<()>(Some(EncryptionFormat::Luks2), None)?;
     let mut token = device.token_handle();
-    let _ = token.json_set(
-        None,
-        &json!({
-            "type": "proto",
-            "keyslots": [],
-            "a_uuid": Uuid::new_v4().to_simple().to_string(),
-            "key_description": key_description
-        }),
-    );
+    let _ = token.json_set(TokenInput::AddToken(&json!({
+        "type": "proto",
+        "keyslots": [],
+        "a_uuid": Uuid::new_v4().to_simple().to_string(),
+        "key_description": key_description
+    })));
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub use luks2_reencrypt::{
 };
 
 mod luks2_token;
-pub use luks2_token::{CryptLuks2Token, CryptTokenInfo};
+pub use luks2_token::{CryptLuks2Token, CryptTokenInfo, TokenInput};
 
 mod mem;
 pub use mem::SafeMemHandle;


### PR DESCRIPTION
Found a couple more spots where Options are required to represent null pointers:

status:

>  For any returned status (besides CRYPT_TOKEN_INVALID
>  * 	   and CRYPT_TOKEN_INACTIVE) and if type parameter is not NULL it will
>  * 	   contain address of type string.


json_set: 

> buffer with JSON or NULL to remove token


I wasn't quite sure how to handle the [error case](https://github.com/stratis-storage/libcryptsetup-rs/compare/master...shimunn:luks2_token_set?expand=1#diff-8940d22d457be16ce7147b2a33300209R68) in when both parameters are None, which would be an undefined operation. Which would either require an separate error variant or for the remove token operation to be moved into it's own function. I'd prefer the latter option but that would mean to deviate slightly from cryptsetups api structure. 

