### PR TITLE
Point at docs.rs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/stratis-storage/libcryptsetup-rs.svg?branch=master)](https://travis-ci.org/stratis-storage/libcryptsetup-rs)
 [![Latest Version](https://img.shields.io/crates/v/libcryptsetup-rs.svg)](https://crates.io/crates/libcryptsetup-rs)
-[![Documentation](https://docs.rs/libcryptsetup-rs/badge.svg)](https://stratis-storage.github.io/libcryptsetup-rs/doc/libcryptsetup_rs/index.html)
+[![Documentation](https://docs.rs/libcryptsetup-rs/badge.svg)](https://docs.rs/libcryptsetup-rs/)
 
 # libcryptsetup-rs
 


### PR DESCRIPTION
The infrastructure on docs.rs now has a recent enough version of libcryptsetup to build libcryptsetup-rs. Point at the official docs.rs docs in the README.

See [here](https://github.com/jbaublitz/libcryptsetup-rs/tree/update-readme) for the working badge link.