### PR TITLE
Revert "Temporarily allow beta clippy Travis task to fail"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ addons:
 
 language: rust
 jobs:
-  allow_failures:
-    # Temporarily allow beta lint task to fail
-    - env: TASK=clippy
-      rust: beta
   include:
 
     # MANDATORY CHECKS USING CURRENT DEVELOPMENT TOOLCHAIN


### PR DESCRIPTION
This reverts commit f06d72603387e07346acea21b3846631424de7ca.