### PR TITLE
Update bindgen to 0.54.0

### DIFF
--- a/libcryptsetup-rs-sys/Cargo.toml
+++ b/libcryptsetup-rs-sys/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://stratis-storage.github.io/"
 repository = "https://github.com/stratis-storage/libcryptsetup-rs"
 
 [build-dependencies]
-bindgen = "0.53.0"
+bindgen = "0.54.0"
 pkg-config = "0.3"
 cc = "1.0.45"
 semver = "0.9"


### PR DESCRIPTION
This is required for packaging `libcryptsetup-rs-sys` for Fedora.