### PR TITLE
Revert "Temporarily allow beta clippy Travis task to fail"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ dist: bionic
 
 language: rust
 jobs:
-  allow_failures:
-    # Temporarily allow beta lint task to fail
-    - env: TASK=clippy
-      rust: beta
   include:
 
     # MANDATORY CHECKS USING CURRENT DEVELOPMENT TOOLCHAIN


### PR DESCRIPTION
This reverts commit c4380819e8e06f2ea1edde75821276aaa90db1e3.