### PR TITLE
Bump bindgen dependency to 0.56.0

### DIFF
--- a/libcryptsetup-rs-sys/Cargo.toml
+++ b/libcryptsetup-rs-sys/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://stratis-storage.github.io/"
 repository = "https://github.com/stratis-storage/libcryptsetup-rs"
 
 [build-dependencies]
-bindgen = "0.54.0"
+bindgen = "0.56.0"
 pkg-config = "0.3"
 cc = "1.0.45"
 semver = "0.11"


### PR DESCRIPTION
I am working on updating bindgen to version 0.56.0 in fedora. This is one of the affected projects.
I was able to make a successful local build of a modified rust-libcryptsetup-rs-sys package with bindgen 0.56.0.