### PR TITLE
Increase nix dependency version to 0.23.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ semver = "1.0.0"
 [dev-dependencies]
 base64 = "0.13.0"
 loopdev = "0.2.0"
-nix = "0.22.0"
+nix = "0.23.0"
 rand = "0.8.0"
 
 [features]


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/392