### PR TITLE
Increase nix dependency lower bound to 0.26.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = "./libcryptsetup-rs-sys"
 
 [dependencies]
 either = "1.6.1"
-libc = "0.2.121"
+libc = "0.2.137"
 bitflags = "1.3.2"
 serde_json = "1.0.0"
 lazy_static = "1.4.0"
@@ -36,7 +36,7 @@ semver = "1.0.0"
 [dev-dependencies]
 base64 = "0.13.0"
 loopdev = "0.4.0"
-nix = "0.24.0"
+nix = "0.26.0"
 rand = "0.8.0"
 
 [features]


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/570