### PR TITLE
Wrap CryptParams* in a trait for safe format calls

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -8,7 +8,9 @@ use std::{
     ptr,
 };
 
-use crate::{consts::vals::EncryptionFormat, device::CryptDevice, err::LibcryptErr};
+use crate::{
+    consts::vals::EncryptionFormat, device::CryptDevice, err::LibcryptErr, format::CryptParams,
+};
 
 use either::Either;
 use uuid::Uuid;
@@ -32,7 +34,7 @@ impl<'a> CryptContextHandle<'a> {
     /// For the `volume_key` parameter, the value in `Either::Right` must be in
     /// units of bytes. For a common key length such as 512 bits, the value passed
     /// to the `Either::Right` variant would be `512 / 8`.
-    pub fn format<T>(
+    pub fn format<T: CryptParams>(
         &mut self,
         type_: EncryptionFormat,
         cipher_and_mode: (&str, &str),
@@ -59,15 +61,13 @@ impl<'a> CryptContextHandle<'a> {
             uuid_ptr,
             volume_key_ptr,
             volume_key_len,
-            params
-                .map(|p| p as *mut _ as *mut c_void)
-                .unwrap_or(ptr::null_mut()),
+            params.map(|p| p.as_ptr()).unwrap_or(ptr::null_mut()),
         )))?;
         Ok(())
     }
 
     /// Convert to new format type
-    pub fn convert<T>(
+    pub fn convert<T: CryptParams>(
         &mut self,
         type_: EncryptionFormat,
         params: &mut T,
@@ -75,7 +75,7 @@ impl<'a> CryptContextHandle<'a> {
         errno!(mutex!(libcryptsetup_rs_sys::crypt_convert(
             self.reference.as_ptr(),
             type_.as_ptr(),
-            params as *mut _ as *mut c_void,
+            params.as_ptr(),
         )))
     }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -2,7 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::{ffi::CString, os::raw::c_uint, path::PathBuf, ptr, slice};
+use std::{
+    ffi::{c_void, CString},
+    os::raw::c_uint,
+    path::PathBuf,
+    ptr, slice,
+};
 
 use crate::{
     consts::{
@@ -13,6 +18,16 @@ use crate::{
     err::LibcryptErr,
     settings::{CryptPbkdfType, CryptPbkdfTypeRef},
 };
+
+pub trait CryptParams {
+    fn as_ptr(&mut self) -> *mut c_void;
+}
+
+impl CryptParams for () {
+    fn as_ptr(&mut self) -> *mut c_void {
+        ptr::null_mut()
+    }
+}
 
 /// A struct with a lifetime representing a reference to `CryptParamsLuks1`.
 pub struct CryptParamsLuks1Ref<'a> {
@@ -76,6 +91,12 @@ impl<'a> TryInto<CryptParamsLuks1Ref<'a>> for &'a CryptParamsLuks1 {
             hash_cstring,
             data_device_cstring,
         })
+    }
+}
+
+impl<'a> CryptParams for CryptParamsLuks1Ref<'a> {
+    fn as_ptr(&mut self) -> *mut c_void {
+        &mut self.inner as *mut _ as *mut c_void
     }
 }
 
@@ -226,6 +247,12 @@ impl<'a> TryInto<CryptParamsLuks2Ref<'a>> for &'a CryptParamsLuks2 {
     }
 }
 
+impl<'a> CryptParams for CryptParamsLuks2Ref<'a> {
+    fn as_ptr(&mut self) -> *mut c_void {
+        &mut self.inner as *mut _ as *mut c_void
+    }
+}
+
 /// Reference to parameters specific to Verity
 pub struct CryptParamsVerityRef<'a> {
     /// C representation of the struct to use with FFI
@@ -330,6 +357,12 @@ impl<'a> TryInto<CryptParamsVerityRef<'a>> for &'a CryptParamsVerity {
     }
 }
 
+impl<'a> CryptParams for CryptParamsVerityRef<'a> {
+    fn as_ptr(&mut self) -> *mut c_void {
+        &mut self.inner as *mut _ as *mut c_void
+    }
+}
+
 /// C-compatible reference to a `CryptParamsLoopaes` struct
 pub struct CryptParamsLoopaesRef<'a> {
     /// C representation of the struct to use with FFI
@@ -376,6 +409,12 @@ impl<'a> TryInto<CryptParamsLoopaesRef<'a>> for &'a CryptParamsLoopaes {
             reference: self,
             hash_cstring,
         })
+    }
+}
+
+impl<'a> CryptParams for CryptParamsLoopaesRef<'a> {
+    fn as_ptr(&mut self) -> *mut c_void {
+        &mut self.inner as *mut _ as *mut c_void
     }
 }
 
@@ -490,6 +529,12 @@ impl<'a> TryFrom<&'a libcryptsetup_rs_sys::crypt_params_integrity> for CryptPara
     }
 }
 
+impl<'a> CryptParams for CryptParamsIntegrityRef<'a> {
+    fn as_ptr(&mut self) -> *mut c_void {
+        &mut self.inner as *mut _ as *mut c_void
+    }
+}
+
 /// Represents a reference to a `CryptParamsPlain` struct
 pub struct CryptParamsPlainRef<'a> {
     /// C FFI-compatible field
@@ -544,6 +589,12 @@ impl<'a> TryFrom<&'a libcryptsetup_rs_sys::crypt_params_plain> for CryptParamsPl
             size: v.size,
             skip: v.skip,
         })
+    }
+}
+
+impl<'a> CryptParams for CryptParamsPlainRef<'a> {
+    fn as_ptr(&mut self) -> *mut c_void {
+        &mut self.inner as *mut _ as *mut c_void
     }
 }
 
@@ -654,6 +705,12 @@ impl<'a> TryFrom<&'a libcryptsetup_rs_sys::crypt_params_tcrypt> for CryptParamsT
             key_size: v.key_size,
             veracrypt_pim: v.veracrypt_pim,
         })
+    }
+}
+
+impl<'a> CryptParams for CryptParamsTcryptRef<'a> {
+    fn as_ptr(&mut self) -> *mut c_void {
+        &mut self.inner as *mut _ as *mut c_void
     }
 }
 


### PR DESCRIPTION

Using the following test program (based on https://github.com/stratis-storage/stratisd/blob/60d007b13414b0253714c557bf02cb4c9a525989/src/engine/strat_engine/backstore/crypt/handle.rs#L335 ) we have uncovered an invalid pointer dereference in arguments passed to format and convert operations: 

```rust 
use libcryptsetup_rs::consts::flags::CryptVolumeKey; 
use libcryptsetup_rs::consts::vals::EncryptionFormat; 
use libcryptsetup_rs::CryptInit; 
use libcryptsetup_rs::CryptParamsLuks2; 
use libcryptsetup_rs::CryptParamsLuks2Ref; 
use libcryptsetup_rs::LibcryptErr; 
use std::path::Path; 

fn encrypt(path: &Path, params: &CryptParamsLuks2) -> Result<(), LibcryptErr> { 
    let mut device = CryptInit::init(path)?; 
    let mut params_ref: CryptParamsLuks2Ref = params.try_into().expect("unable to convert"); 
    device.context_handle().format( 
        EncryptionFormat::Luks2, 
        ("aes", "xts-plain"), 
        None, 
        libcryptsetup_rs::Either::Right(256 / 8), 
        Some(&mut params_ref), 
    )?; 
    device 
        .keyslot_handle() 
        .add_by_key(None, None, b"changeme", CryptVolumeKey::empty())?; 
    Ok(()) 
} 

fn main() { 
    let luks2_params = CryptParamsLuks2 { 
        pbkdf: None, 
        integrity: None, 
        integrity_params: None, 
        data_alignment: 0, 
        data_device: None, 
        sector_size: 0, 
        label: Some("a-label".to_string()), 
        subsystem: None, 
    }; 

    match encrypt(Path::new("./test.img"), &luks2_params) { 
        Err(e) => panic!("Error {}", e), 
        Ok(()) => {} 
    } 
} 
``` 


If we run the above against libcryptsetup-rs = 0.7.0 with the latest nightly rustc, we get the following error: 
``` 
$ cargo +nightly build 
   Compiling libcryptsetup-test v0.1.0 
    Finished dev [unoptimized + debuginfo] target(s) in 0.25s 
$ ./target/debug/libcryptsetup-test 
thread 'main' panicked at 'Error IO error occurred: Invalid argument (os error 22)', src/main.rs:41:19 
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace 
``` 

After much step debugging, we discovered that the issue is that Rust structs are not guaranteed to be laid out in memory in the order they were declared in code. When void * casting CryptParamsLuks2Ref to the library interface seems to rely on the `.inner` parameter being first in the struct. Rust does not guarantee ordering by default https://doc.rust-lang.org/reference/type-layout.html#the-default-representation . This PR should ensure that the correct pointer address is always used regardless of the actual ordering of elements in the CryptParams*Ref structs. Also, this change should be backward compatible with the previous interface. 

For reference, here is the actual memory layout between working and non-working builds: 

Working 
``` 
(gdb) print &params 
$4 = (*mut libcryptsetup_rs::format::CryptParamsLuks2Ref) 0x7fffffff1000 
(gdb) print &params.inner 
$5 = (*mut libcryptsetup_rs_sys::crypt_params_luks2) 0x7fffffff1000 
``` 

Broken 
``` 
(gdb) print &params 
$4 = (*mut libcryptsetup_rs::format::CryptParamsLuks2Ref) 0x7fffffff05e0 
(gdb) print &params.inner 
$5 = (*mut libcryptsetup_rs_sys::crypt_params_luks2) 0x7fffffff05e8 
``` 
Note that the address of params.inner is 8 bytes off from that of params. It turns out the compiler reordered params.reference above params.inner.