### PR TITLE
Increase nix dependency lower bound to 0.27.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ semver = "1.0.0"
 base64 = "0.21.0"
 env_logger = "0.10.0"
 loopdev = "0.4.0"
-nix = "0.26.0"
+nix = {version="0.27.1", features=["user"]}
 rand = "0.8.0"
 
 [features]


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/672