### PR TITLE
Allow specifying key length in add_by_key

### DIFF
--- a/src/keyslot.rs
+++ b/src/keyslot.rs
@@ -7,6 +7,7 @@ use std::{
     ptr,
 };
 
+use either::Either;
 use libc::{c_int, c_uint};
 
 use crate::{
@@ -111,12 +112,13 @@ impl<'a> CryptKeyslotHandle<'a> {
     pub fn add_by_key(
         &mut self,
         keyslot: Option<c_uint>,
-        volume_key: Option<&[u8]>,
+        volume_key: Option<Either<&[u8], usize>>,
         passphrase: &[u8],
         flags: CryptVolumeKey,
     ) -> Result<c_uint, LibcryptErr> {
         let (vk_ptr, vk_len) = match volume_key {
-            Some(vk) => (to_byte_ptr!(vk), vk.len()),
+            Some(Either::Left(vk)) => (to_byte_ptr!(vk), vk.len()),
+            Some(Either::Right(s)) => (std::ptr::null(), s),
             None => (std::ptr::null(), 0),
         };
         errno_int_success!(mutex!(libcryptsetup_rs_sys::crypt_keyslot_add_by_key(


### PR DESCRIPTION
Related to stratis-storage/stratisd#3651

There is another set of values that can be passed in that is not currently exposed.

`None` currently uses the key length specified by the format call
`Some` allows you to specify a key

However, in the case of of a `NO_SEGMENT` key, you need to be able to specify no key but provide a key length as it cannot inherit this from the format call on an existing crypt device.

This PR exposes the API as follows:

`None` uses the key length specified by the format call
`Some(Either::Left(_))` allows you to specify a key
`Some(Either::Right(_))` allows you to specify a key length

This will be a breaking change and will require a minor version bump.