### PR TITLE
Increase GitHub Action checkout version to v5

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: libcryptsetup-rs
+          persist-credentials: false
       - name: Install dependencies for Fedora
         run: >
           dnf install -y
@@ -47,6 +48,7 @@ jobs:
         with:
           path: ci
           repository: stratis-storage/ci
+          persist-credentials: false
       - name: Run comparisons of -sys version specs with Fedora
         # yamllint disable rule:line-length
         run: |

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Install git
         run: dnf install -y git
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: libcryptsetup-rs
       - name: Install dependencies for Fedora
@@ -43,7 +43,7 @@ jobs:
           components: cargo
           toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
       - name: Check out ci repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: ci
           repository: stratis-storage/ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Install git
         run: sudo apt-get install git
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Install git
         run: sudo apt-get install git
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           components: clippy
@@ -60,7 +60,7 @@ jobs:
     steps:
       - name: Install git
         run: sudo apt-get install git
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.TOOLCHAIN }}
@@ -96,7 +96,7 @@ jobs:
     steps:
       - name: Install git
         run: sudo apt-get install git
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.TOOLCHAIN }}
@@ -123,7 +123,7 @@ jobs:
     steps:
       - name: Install git
         run: sudo apt-get install git
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.TOOLCHAIN }}
@@ -226,7 +226,7 @@ jobs:
     steps:
       - name: Install git
         run: dnf install -y git
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.TOOLCHAIN }}
@@ -242,7 +242,7 @@ jobs:
     steps:
       - name: Install git
         run: dnf install -y git
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install dependencies
         run: dnf install -y make yamllint
       - name: Run yamllint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Install git
         run: sudo apt-get install git
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
@@ -43,6 +45,8 @@ jobs:
       - name: Install git
         run: sudo apt-get install git
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
           components: clippy
@@ -61,6 +65,8 @@ jobs:
       - name: Install git
         run: sudo apt-get install git
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.TOOLCHAIN }}
@@ -97,6 +103,8 @@ jobs:
       - name: Install git
         run: sudo apt-get install git
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.TOOLCHAIN }}
@@ -124,6 +132,8 @@ jobs:
       - name: Install git
         run: sudo apt-get install git
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.TOOLCHAIN }}
@@ -227,6 +237,8 @@ jobs:
       - name: Install git
         run: dnf install -y git
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.TOOLCHAIN }}
@@ -243,6 +255,8 @@ jobs:
       - name: Install git
         run: dnf install -y git
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: dnf install -y make yamllint
       - name: Run yamllint

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Install git
         run: sudo apt-get install git
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
           components: cargo
@@ -38,6 +40,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: libcryptsetup-rs
+          persist-credentials: false
       - name: Install dependencies for Fedora
         run: >
           dnf install -y
@@ -57,6 +60,7 @@ jobs:
         with:
           path: ci
           repository: stratis-storage/ci
+          persist-credentials: false
       - name: Run comparisons of version specs with -sys package
         # yamllint disable rule:line-length
         run: |
@@ -78,6 +82,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: |
           sudo apt-get -q update

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Install git
         run: sudo apt-get install git
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           components: cargo
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Install git
         run: dnf install -y git
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: libcryptsetup-rs
       - name: Install dependencies for Fedora
@@ -53,7 +53,7 @@ jobs:
           components: cargo
           toolchain: 1.89.0  # CURRENT DEVELOPMENT RUST TOOLCHAIN
       - name: Check out ci repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: ci
           repository: stratis-storage/ci
@@ -77,7 +77,7 @@ jobs:
   semver-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install dependencies
         run: |
           sudo apt-get -q update


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/807

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Upgraded CI to use the latest repository checkout action across all workflows.
  * Disabled credential persistence in CI to improve security.
  * Enhances reliability and maintainability of the build pipeline.
  * No user-facing changes; application behavior and release artifacts remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->