### PR TITLE
Make LUKS info in reencryption optional

### DIFF
--- a/src/tests/reencrypt.rs
+++ b/src/tests/reencrypt.rs
@@ -80,7 +80,7 @@ pub fn test_reencrypt_by_password() {
                         data_shift: 0,
                         max_hotzone_size: 0,
                         device_size: 0,
-                        luks2: CryptParamsLuks2 {
+                        luks2: Some(CryptParamsLuks2 {
                             data_alignment: 0,
                             data_device: None,
                             integrity: None,
@@ -89,7 +89,7 @@ pub fn test_reencrypt_by_password() {
                             label: None,
                             sector_size: size,
                             subsystem: None,
-                        },
+                        }),
                         flags: CryptReencrypt::empty(),
                     },
                 )


### PR DESCRIPTION
Related to https://github.com/stratis-storage/stratisd/issues/3597

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Re-encryption now works without requiring LUKS2-specific parameters. You can initiate reencryption with defaults when LUKS2 options are omitted, improving flexibility and simplifying common workflows.
  - Graceful handling of missing LUKS2 settings ensures compatibility across environments where those parameters aren’t provided, with safe fallbacks applied automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->