### PR TITLE
libcryptsetup-rs v0.14.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,20 @@
+libcryptsetup-rs 0.14.0
+=======================
+Recommended Rust toolchain version: 1.89.0
+Recommended development environment: Fedora 41
+
+- Make LUKS info in reencryption optional:
+  https://github.com/stratis-storage/libcryptsetup-rs/pull/447
+
+- Increase lowest supported Rust to 1.77:
+  https://github.com/stratis-storage/libcryptsetup-rs/pull/444
+
+- Tidies and Maintenance:
+  https://github.com/stratis-storage/libcryptsetup-rs/pull/445
+  https://github.com/stratis-storage/libcryptsetup-rs/pull/443
+  https://github.com/stratis-storage/libcryptsetup-rs/pull/442
+
+
 libcryptsetup-rs 0.13.2
 =======================
 Recommended Rust toolchain version: 1.88.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcryptsetup-rs"
-version = "0.13.2"
+version = "0.14.0"
 authors = ["John Baublitz <jbaublitz@redhat.com>"]
 edition = "2021"
 rust-version = "1.77.0"  # LOWEST SUPPORTED RUST TOOLCHAIN


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added 0.14.0 release notes to the changelog, noting recommended Rust 1.89.0 and Fedora 41, raised minimum supported Rust to 1.77, optional LUKS info in reencryption, and maintenance updates.
- Chores
  - Bumped crate version from 0.13.2 to 0.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->