### PR TITLE
Fix error code in is_assigned

### DIFF
--- a/src/luks2/token.rs
+++ b/src/luks2/token.rs
@@ -222,7 +222,7 @@ impl<'a> CryptLuks2TokenHandle<'a> {
         ));
         if rc == 0 {
             Ok(true)
-        } else if rc == libc::ENOENT {
+        } else if rc == -libc::ENOENT {
             Ok(false)
         } else {
             Err(LibcryptErr::IOError(std::io::Error::from_raw_os_error(-rc)))


### PR DESCRIPTION
The C function `crypt_token_is_assigned` returns `-ENOENT` when the token is unassigned.